### PR TITLE
Prevent empty command graceful exit

### DIFF
--- a/misterio.sh
+++ b/misterio.sh
@@ -16,7 +16,7 @@ The technology is based only on docker compose (no docker swarm)
 
 
 EOF
-exit
+exit 1
 fi
 
 set -e


### PR DESCRIPTION
Using automation, an empty command should be threated as invalid input and have to fail.